### PR TITLE
Fix bottom corner validators

### DIFF
--- a/Lunette.spoon/resize.lua
+++ b/Lunette.spoon/resize.lua
@@ -27,8 +27,8 @@ function obj:fullScreen(window, screen)
 end
 
 function obj:center(window, screen)
-  window.x = ((screen.w - window.w) / 2) + screen.x
-  window.y = ((screen.h - window.h) / 2) + screen.y
+  window.x = ((screen.w - window.w) // 2) + screen.x
+  window.y = ((screen.h - window.h) // 2) + screen.y
 
   return window
 end
@@ -46,7 +46,7 @@ function obj:topHalf(window, screen)
   window.x = screen.x
   window.y = screen.y
   window.w = screen.w
-  window.h = screen.h / 2
+  window.h = screen.h // 2
 
   return window
 end
@@ -54,8 +54,8 @@ end
 function obj:topLeftHalf(window, screen)
   window.x = screen.x
   window.y = screen.y
-  window.w = screen.w / 2
-  window.h = screen.h / 2
+  window.w = screen.w // 2
+  window.h = screen.h // 2
 
   return window
 end
@@ -63,8 +63,8 @@ end
 function obj:topLeftThird(window, screen)
   window.x = screen.x
   window.y = screen.y
-  window.w = screen.w / 3
-  window.h = screen.h / 2
+  window.w = screen.w // 3
+  window.h = screen.h // 2
 
   return window
 end
@@ -72,35 +72,35 @@ end
 function obj:topLeftTwoThirds(window, screen)
   window.x = screen.x
   window.y = screen.y
-  window.w = (screen.w / 3) * 2
-  window.h = screen.h / 2
+  window.w = (screen.w // 3) * 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:topRightHalf(window, screen)
-  window.x = (screen.w / 2) + screen.x
+  window.x = (screen.w // 2) + screen.x
   window.y = screen.y
-  window.w = screen.w / 2
-  window.h = screen.h / 2
+  window.w = screen.w // 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:topRightThird(window, screen)
-  window.x = ((screen.w / 3) * 2) + screen.x
+  window.x = ((screen.w // 3) * 2) + screen.x
   window.y = screen.y
-  window.w = screen.w / 3
-  window.h = screen.h / 2
+  window.w = screen.w // 3
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:topRightTwoThirds(window, screen)
-  window.x = (screen.w / 3) + screen.x
+  window.x = (screen.w // 3) + screen.x
   window.y = screen.y
-  window.w = (screen.w / 3) * 2
-  window.h = screen.h / 2
+  window.w = (screen.w // 3) * 2
+  window.h = screen.h // 2
 
   return window
 end
@@ -109,7 +109,7 @@ function obj:topThird(window, screen)
   window.x = screen.x
   window.y = screen.y
   window.w = screen.w
-  window.h = screen.h / 3
+  window.h = screen.h // 3
 
   return window
 end
@@ -118,88 +118,88 @@ function obj:topTwoThirds(window, screen)
   window.x = screen.x
   window.y = screen.y
   window.w = screen.w
-  window.h = (screen.h / 3) * 2
+  window.h = (screen.h // 3) * 2
 
   return window
 end
 
 function obj:bottomHalf(window, screen)
   window.x = screen.x
-  window.y = (screen.h / 2) + screen.y
+  window.y = (screen.h // 2) + screen.y
   window.w = screen.w
-  window.h = screen.h / 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomLeftHalf(window, screen)
   window.x = screen.x
-  window.y = (screen.h / 2) + screen.y
-  window.w = screen.w / 2
-  window.h = screen.h / 2
+  window.y = (screen.h // 2) + screen.y
+  window.w = screen.w // 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomLeftThird(window, screen)
   window.x = screen.x
-  window.y = (screen.h / 2) + screen.y
-  window.w = screen.w / 3
-  window.h = screen.h / 2
+  window.y = (screen.h // 2) + screen.y
+  window.w = screen.w // 3
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomLeftTwoThirds(window, screen)
   window.x = screen.x
-  window.y = (screen.h / 2) + screen.y
-  window.w = (screen.w / 3) * 2
-  window.h = screen.h / 2
+  window.y = (screen.h // 2) + screen.y
+  window.w = (screen.w // 3) * 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomRightHalf(window, screen)
-  window.x = (screen.w / 2) + screen.x
-  window.y = (screen.h / 2) + screen.y
-  window.w = screen.w / 2
-  window.h = screen.h / 2
+  window.x = (screen.w // 2) + screen.x
+  window.y = (screen.h // 2) + screen.y
+  window.w = screen.w // 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomRightThird(window, screen)
-  window.x = ((screen.w / 3) * 2) + screen.x
-  window.y = (screen.h / 2) + screen.y
-  window.w = screen.w / 3
-  window.h = screen.h / 2
+  window.x = ((screen.w // 3) * 2) + screen.x
+  window.y = (screen.h // 2) + screen.y
+  window.w = screen.w // 3
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomRightTwoThirds(window, screen)
-  window.x = (screen.w / 3) + screen.x
-  window.y = (screen.h / 2) + screen.y
-  window.w = (screen.w / 3) * 2
-  window.h = screen.h / 2
+  window.x = (screen.w // 3) + screen.x
+  window.y = (screen.h // 2) + screen.y
+  window.w = (screen.w // 3) * 2
+  window.h = screen.h // 2
 
   return window
 end
 
 function obj:bottomThird(window, screen)
   window.x = screen.x
-  window.y = ((screen.h / 3) * 2) + screen.y
+  window.y = ((screen.h // 3) * 2) + screen.y
   window.w = screen.w
-  window.h = screen.h / 3
+  window.h = screen.h // 3
 
   return window
 end
 
 function obj:bottomTwoThirds(window, screen)
   window.x = screen.x
-  window.y = (screen.h / 3) + screen.y
+  window.y = (screen.h // 3) + screen.y
   window.w = screen.w
-  window.h = (screen.h / 3) * 2
+  window.h = (screen.h // 3) * 2
 
   return window
 end
@@ -207,7 +207,7 @@ end
 function obj:leftHalf(window, screen)
   window.x = screen.x
   window.y = screen.y
-  window.w = screen.w / 2
+  window.w = screen.w // 2
   window.h = screen.h
 
   return window
@@ -216,7 +216,7 @@ end
 function obj:leftThird(window, screen)
   window.x = screen.x
   window.y = screen.y
-  window.w = screen.w / 3
+  window.w = screen.w // 3
   window.h = screen.h
 
   return window
@@ -225,34 +225,34 @@ end
 function obj:leftTwoThirds(window, screen)
   window.x = screen.x
   window.y = screen.y
-  window.w = (screen.w / 3) * 2
+  window.w = (screen.w // 3) * 2
   window.h = screen.h
 
   return window
 end
 
 function obj:rightHalf(window, screen)
-  window.x = (screen.w / 2) + screen.x
+  window.x = (screen.w // 2) + screen.x
   window.y = screen.y
-  window.w = screen.w / 2
+  window.w = screen.w // 2
   window.h = screen.h
 
   return window
 end
 
 function obj:rightThird(window, screen)
-  window.x = (screen.w / 3) * 2 + screen.x
+  window.x = (screen.w // 3) * 2 + screen.x
   window.y = screen.y
-  window.w = screen.w / 3
+  window.w = screen.w // 3
   window.h = screen.h
 
   return window
 end
 
 function obj:rightTwoThirds(window, screen)
-  window.x = (screen.w / 3) + screen.x
+  window.x = (screen.w // 3) + screen.x
   window.y = screen.y
-  window.w = (screen.w / 3) * 2
+  window.w = (screen.w // 3) * 2
   window.h = screen.h
 
   return window
@@ -260,17 +260,17 @@ end
 
 function obj:centerHorizontalThird(window, screen)
   window.x = screen.x
-  window.y = screen.h / 3
+  window.y = screen.h // 3
   window.w = screen.w
-  window.h = screen.h / 3
+  window.h = screen.h // 3
 
   return window
 end
 
 function obj:centerVerticalThird(window, screen)
-  window.x = screen.w / 3
+  window.x = screen.w // 3
   window.y = screen.y
-  window.w = screen.w / 3
+  window.w = screen.w // 3
   window.h = screen.h
 
   return window

--- a/Lunette.spoon/validator.lua
+++ b/Lunette.spoon/validator.lua
@@ -6,187 +6,187 @@ function obj:topHalf(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
          window.w == screen.w and
-         window.h == (screen.h / 2)
+         window.h == (screen.h // 2)
 end
 
 function obj:topThird(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
          window.w == screen.w and
-         math.floor(window.h) == math.floor(screen.h / 3)
+         window.h == (screen.h // 3)
 end
 
 function obj:topTwoThirds(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
          window.w == screen.w and
-         math.floor(window.h) == math.floor((screen.h / 3) * 2)
+         window.h == ((screen.h // 3) * 2)
 end
 
 function obj:topLeftHalf(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
-         window.w == screen.w / 2 and
-         window.h == screen.h / 2
+         window.w == screen.w // 2 and
+         window.h == screen.h // 2
 end
 
 function obj:topLeftThird(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
-         window.h == screen.h / 2
+         window.w == (screen.w // 3) and
+         window.h == screen.h // 2
 end
 
 function obj:topLeftTwoThirds(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
-         math.floor(window.w) == math.floor((screen.w / 3) * 2) and
-         window.h == screen.h / 2
+         window.w == ((screen.w // 3) * 2) and
+         window.h == screen.h // 2
 end
 
 function obj:topRightHalf(window, screen)
-  return window.x == (screen.w / 2) + screen.x and
+  return window.x == (screen.w // 2) + screen.x and
          window.y == screen.y and
-         window.w == screen.w / 2 and
-         window.h == screen.h / 2
+         window.w == screen.w // 2 and
+         window.h == screen.h // 2
 end
 
 function obj:topRightThird(window, screen)
-  return math.floor(window.x) == math.floor(((screen.w / 3) * 2) + screen.x) and
+  return window.x == (((screen.w // 3) * 2) + screen.x) and
          window.y == screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
-         window.h == screen.h / 2
+         window.w == (screen.w // 3) and
+         window.h == screen.h // 2
 end
 
 function obj:topRightTwoThirds(window, screen)
-  return math.floor(window.x) == math.floor((screen.w / 3) + screen.x) and
+  return window.x == ((screen.w // 3) + screen.x) and
          window.y == screen.y and
-         math.floor(window.w) == math.floor((screen.w / 3) * 2) and
-         window.h == screen.h / 2
+         window.w == ((screen.w // 3) * 2) and
+         window.h == screen.h // 2
 end
 
 function obj:bottomHalf(window, screen)
   return window.x == screen.x and
-         window.y == (screen.h / 2) + screen.y and
+         window.y == (screen.h // 2) + screen.y and
          window.w == screen.w and
-         window.h == screen.h / 2
+         window.h == screen.h // 2
 end
 
 function obj:bottomThird(window, screen)
   return window.x == screen.x and
-         math.floor(window.y) == math.floor(((screen.h / 3) * 2) + screen.y) and
+         window.y == (((screen.h // 3) * 2) + screen.y) and
          window.w == screen.w and
-         math.floor(window.h) == math.floor(screen.h / 3)
+         window.h == (screen.h // 3)
 end
 
 function obj:bottomTwoThirds(window, screen)
   return window.x == screen.x and
-         math.floor(window.y) == math.floor((screen.h / 3) + screen.y) and
+         window.y == ((screen.h // 3) + screen.y) and
          window.w == screen.w and
-         math.floor(window.h) == math.floor((screen.h / 3) * 2)
+         window.h == ((screen.h // 3) * 2)
 end
 
 function obj:bottomLeftHalf(window, screen)
   return window.x == screen.x and
-         window.y == screen.h / 2 + screen.y and
-         window.w == screen.w / 2 and
-         window.h == screen.h / 2
+         window.y == screen.h // 2 + screen.y and
+         window.w == screen.w // 2 and
+         window.h == screen.h // 2
 end
 
 function obj:bottomLeftThird(window, screen)
   return window.x == screen.x and
-         window.y == (screen.h / 2) + screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
-         window.h == screen.h / 2
+         window.y == (screen.h // 2) + screen.y and
+         window.w == (screen.w // 3) and
+         window.h == screen.h // 2
 end
 
 function obj:bottomLeftTwoThirds(window, screen)
   return window.x == screen.x and
-         window.y == (screen.h / 2) + screen.y and
-         math.floor(window.w) == math.floor((screen.w / 3) * 2) and
-         window.h == screen.h / 2
+         window.y == (screen.h // 2) + screen.y and
+         window.w == ((screen.w // 3) * 2) and
+         window.h == screen.h // 2
 end
 
 function obj:bottomRightThird(window, screen)
-  return math.floor(window.x) == math.floor((screen.w / 3) * 2) and
-         window.y == (screen.h / 2) + screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
-         window.h == screen.h / 2
+  return window.x == ((screen.w // 3) * 2) and
+         window.y == (screen.h // 2) + screen.y and
+         window.w == (screen.w // 3) and
+         window.h == screen.h // 2
 end
 
 function obj:bottomRightTwoThirds(window, screen)
-  return math.floor(window.x) == math.floor(screen.w / 3) + screen.x and
-         window.y == (screen.h / 2) + screen.y and
-         math.floor(window.w) == math.floor((screen.w / 3) * 2) and
-         window.h == screen.h / 2
+  return window.x == (screen.w // 3) + screen.x and
+         window.y == (screen.h // 2) + screen.y and
+         window.w == ((screen.w // 3) * 2) and
+         window.h == screen.h // 2
 end
 
 function obj:bottomRightHalf(window, screen)
-  return window.x == (screen.w / 2) + screen.x and
-         window.y == (screen.h / 2) + screen.y and
-         window.w == screen.w / 2 and
-         window.h == screen.h / 2
+  return window.x == (screen.w // 2) + screen.x and
+         window.y == (screen.h // 2) + screen.y and
+         window.w == screen.w // 2 and
+         window.h == screen.h // 2
 end
 
 function obj:leftHalf(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
-         window.w == screen.w / 2 and
+         window.w == screen.w // 2 and
          window.h == screen.h
 end
 
 function obj:leftThird(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
+         window.w == (screen.w // 3) and
          window.h == screen.h
 end
 
 function obj:leftTwoThirds(window, screen)
   return window.x == screen.x and
          window.y == screen.y and
-         math.floor(window.w) == math.floor((screen.w / 3) * 2) and
+         window.w == ((screen.w // 3) * 2) and
          window.h == screen.h
 end
 
 function obj:rightHalf(window, screen)
-  return window.x == (screen.w / 2) + screen.x and
+  return window.x == (screen.w // 2) + screen.x and
          window.y == screen.y and
-         window.w == screen.w / 2 and
+         window.w == screen.w // 2 and
          window.h == screen.h
 end
 
 function obj:rightThird(window, screen)
-  return math.floor(window.x) == math.floor((screen.w / 3) * 2 + screen.x) and
+  return window.x == ((screen.w // 3) * 2 + screen.x) and
          window.y == screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
+         window.w == (screen.w // 3) and
          window.h == screen.h
 end
 
 function obj:rightTwoThirds(window, screen)
-  return math.floor(window.x) == math.floor((screen.w / 3) + screen.x) and
+  return window.x == ((screen.w // 3) + screen.x) and
          window.y == screen.y and
-         math.floor(window.w) == math.floor((screen.w / 3) * 2) and
+         window.w == ((screen.w // 3) * 2) and
          window.h == screen.h
 end
 
 function obj:centerHorizontalThird(window, screen)
   return window.x == screen.x and
-         math.floor(window.y) == math.floor(screen.h / 3) and
+         window.y == (screen.h // 3) and
          window.w == screen.w and
-         math.floor(window.h) == math.floor(screen.h / 3)
+         window.h == (screen.h // 3)
 end
 
 function obj:centerVerticalThird(window, screen)
-  return math.floor(window.x) == math.floor(screen.w / 3) and
+  return window.x == (screen.w // 3) and
          window.y == screen.y and
-         math.floor(window.w) == math.floor(screen.w / 3) and
+         window.w == (screen.w // 3) and
          window.h == screen.h
 end
 
 function obj:inScreenBounds(window, screen)
-  return math.floor(window.w) <= math.floor(screen.w) and
-         math.floor(window.h) <= math.floor(screen.h)
+  return window.w <= screen.w and
+         window.h <= screen.h
 end
 
 return obj

--- a/Lunette.spoon/validator.lua
+++ b/Lunette.spoon/validator.lua
@@ -88,35 +88,35 @@ end
 
 function obj:bottomLeftHalf(window, screen)
   return window.x == screen.x and
-         window.y == screen.h / 2 and
+         window.y == screen.h / 2 + screen.y and
          window.w == screen.w / 2 and
          window.h == screen.h / 2
 end
 
 function obj:bottomLeftThird(window, screen)
   return window.x == screen.x and
-         window.y == screen.h / 2 and
+         window.y == (screen.h / 2) + screen.y and
          math.floor(window.w) == math.floor(screen.w / 3) and
          window.h == screen.h / 2
 end
 
 function obj:bottomLeftTwoThirds(window, screen)
   return window.x == screen.x and
-         window.y == screen.h / 2 and
+         window.y == (screen.h / 2) + screen.y and
          math.floor(window.w) == math.floor((screen.w / 3) * 2) and
          window.h == screen.h / 2
 end
 
 function obj:bottomRightThird(window, screen)
   return math.floor(window.x) == math.floor((screen.w / 3) * 2) and
-         window.y == screen.h / 2 and
+         window.y == (screen.h / 2) + screen.y and
          math.floor(window.w) == math.floor(screen.w / 3) and
          window.h == screen.h / 2
 end
 
 function obj:bottomRightTwoThirds(window, screen)
-  return math.floor(window.x) == math.floor(screen.w / 3) and
-         window.y == screen.h / 2 and
+  return math.floor(window.x) == math.floor(screen.w / 3) + screen.x and
+         window.y == (screen.h / 2) + screen.y and
          math.floor(window.w) == math.floor((screen.w / 3) * 2) and
          window.h == screen.h / 2
 end


### PR DESCRIPTION
Previously, bottom corners weren't working as desired. Specifically,
bottom-left would get stuck at the half-screen, and bottom-right would
get stuck at two-thirds. This is because they weren't accounting for the
vertical screen offset.

Also, using integer division (present as of Lua 5.3) to eliminate potential rounding errors and simplify the code. (On my Mojave machine, the screen had an odd pixel height and so half the height would be a float.)