### PR TITLE
Fix wrong default keybinding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Lunette comes with a set of default keybindings. See installation for more on al
 | `bottomRight`| (⌃ ⌘ ⇧) →       |
 | `nextDisplay`| (⌃ ⌥ ⌘) →       |
 | `prevDisplay`| (⌃ ⌥ ⌘) ←       |
-| `nextThird`  | (⌃ ⌥ ⌘) →       |
-| `prevThird`  | (⌃ ⌥ ⌘) ←       |
+| `nextThird`  | (⌃ ⌥) →       |
+| `prevThird`  | (⌃ ⌥) ←       |
 | `enlarge`    | (⌃ ⌥ ⇧) →       |
 | `shrink`     | (⌃ ⌥ ⇧) ←       |
 | `undo`       | (⌥ ⌘) Z          |


### PR DESCRIPTION
Display and third shortcuts list the same default keybinding while next & prevThird should be without cmd modifier.