### PR TITLE
Adds 3/4ths widths on Left and Right half operations

### DIFF
--- a/Source/Lunette.spoon/command.lua
+++ b/Source/Lunette.spoon/command.lua
@@ -25,6 +25,8 @@ obj.leftHalf = function(windowFrame, screenFrame)
   if Validate:leftHalf(windowFrame, screenFrame) then
     newFrame = Resize:leftTwoThirds(windowFrame, screenFrame)
   elseif Validate:leftTwoThirds(windowFrame, screenFrame) then
+    newFrame = Resize:leftThreeQuarters(windowFrame, screenFrame)
+  elseif Validate:leftThreeQuarters(windowFrame, screenFrame) then
     newFrame = Resize:leftThird(windowFrame, screenFrame)
   else
     newFrame = Resize:leftHalf(windowFrame, screenFrame)
@@ -196,6 +198,8 @@ obj.rightHalf = function(windowFrame, screenFrame)
   if Validate:rightHalf(windowFrame, screenFrame) then
     newFrame = Resize:rightTwoThirds(windowFrame, screenFrame)
   elseif Validate:rightTwoThirds(windowFrame, screenFrame) then
+    newFrame = Resize:rightThreeQuarters(windowFrame, screenFrame)
+  elseif Validate:rightThreeQuarters(windowFrame, screenFrame) then
     newFrame = Resize:rightThird(windowFrame, screenFrame)
   else
     newFrame = Resize:rightHalf(windowFrame, screenFrame)

--- a/Source/Lunette.spoon/resize.lua
+++ b/Source/Lunette.spoon/resize.lua
@@ -231,6 +231,15 @@ function obj:leftTwoThirds(window, screen)
   return window
 end
 
+function obj:leftThreeQuarters(window, screen)
+  window.x = screen.x
+  window.y = screen.y
+  window.w = (screen.w // 4) * 3
+  window.h = screen.h
+
+  return window
+end
+
 function obj:rightHalf(window, screen)
   window.x = (screen.w // 2) + screen.x
   window.y = screen.y
@@ -253,6 +262,15 @@ function obj:rightTwoThirds(window, screen)
   window.x = (screen.w // 3) + screen.x
   window.y = screen.y
   window.w = (screen.w // 3) * 2
+  window.h = screen.h
+
+  return window
+end
+
+function obj:rightThreeQuarters(window, screen)
+  window.x = (screen.w // 4) + screen.x
+  window.y = screen.y
+  window.w = (screen.w // 4) * 3
   window.h = screen.h
 
   return window

--- a/Source/Lunette.spoon/validator.lua
+++ b/Source/Lunette.spoon/validator.lua
@@ -149,6 +149,13 @@ function obj:leftTwoThirds(window, screen)
          window.h == screen.h
 end
 
+function obj:leftThreeQuarters(window, screen)
+  return window.x == screen.x and
+         window.y == screen.y and
+         window.w == ((screen.w // 4) * 3) and
+         window.h == screen.h
+end
+
 function obj:rightHalf(window, screen)
   return window.x == (screen.w // 2) + screen.x and
          window.y == screen.y and
@@ -167,6 +174,13 @@ function obj:rightTwoThirds(window, screen)
   return window.x == ((screen.w // 3) + screen.x) and
          window.y == screen.y and
          window.w == ((screen.w // 3) * 2) and
+         window.h == screen.h
+end
+
+function obj:rightThreeQuarters(window, screen)
+  return window.x == ((screen.w // 4) + screen.x) and
+         window.y == screen.y and
+         window.w == ((screen.w // 4) * 3) and
          window.h == screen.h
 end
 


### PR DESCRIPTION
I don't think this is ready to merge as-is but I thought I'd put it here for discussion. This is a customized Lunette I use that adds a 3/4ths size to the R/L halves operations. This may not be desirable to back into the main line, but I personally would find it extremely useful to have 3/4ths widths on the halves (or some other) operations.

Possible thoughts on bringing this idea in:
1. Could merge as-is. The half operations are already overloaded with 1/3rd and 2/3ds operations anyway.
1. Could merge as-is, with 3/4ths support behind a bool.
1. I could add quarters to the halves operation since it seems unbalanced to offer 3/4ths but not 1/4ths.
1. I could remove this from halves, and add a quarters operation that does 1/4, 1/2, and 3/4 or even 1/4, 1/3, 1/2, 2/3, and 3/4. In the latter case I think it would need a better name than quarters. Maybe the best choice is to add a "thirds" operation that is just 1/3rd and 2/3rds, a "quarters" operation, with 1/4, 1/2, and 3/4ths, and a "slices" operation with all 5 of these widths.

Thoughts? I'm leaning toward the last, adding "quarters", "thirds", and "slices" operations.