### PR TITLE
feat: Support default keybinding

### DIFF
--- a/Source/Lunette.spoon/init.lua
+++ b/Source/Lunette.spoon/init.lua
@@ -25,7 +25,7 @@ obj.spoonPath = script_path()
 obj.Command = dofile(obj.spoonPath.."/command.lua")
 obj.history = dofile(obj.spoonPath.."/history.lua"):init()
 
-obj.DefaultMapping = {
+obj.defaultHotkeys = {
   leftHalf = {
     {{"cmd", "alt"}, "left"},
   },
@@ -86,7 +86,7 @@ function obj:bindHotkeys(userBindings)
   print("Lunette: Binding Hotkeys")
 
   local userBindings = userBindings or {}
-  local bindings = self.DefaultMapping
+  local bindings = self.defaultHotkeys
 
   for command, mappings in pairs(userBindings) do
     bindings[command] = mappings


### PR DESCRIPTION
Update default keybinding definition to support defaults string from hs.spoons.use

Supports using:

hs.spoons.use("Lunette", { hotkeys = "default" })

This is the same as using:

hs.loadSpoon("Lunette")
spoon.Lunette:bindHotkeys(spoon.Lunette.defaultHotkeys)