### PR TITLE
Add `almostFullScreen` command

### DIFF
--- a/Source/Lunette.spoon/command.lua
+++ b/Source/Lunette.spoon/command.lua
@@ -47,6 +47,11 @@ obj.fullScreen = function(windowFrame, screenFrame)
   return newFrame
 end
 
+obj.almostFullScreen = function(windowFrame, screenFrame)
+   local newFrame = Resize:almostFullScreen(windowFrame, screenFrame)
+   return newFrame
+end
+
 --- Command:center(windowFrame, screenFrame)
 --- Method
 --- Inspects current screen frame position, determines how to resize given frame

--- a/Source/Lunette.spoon/init.lua
+++ b/Source/Lunette.spoon/init.lua
@@ -53,6 +53,9 @@ obj.defaultHotkeys = {
   fullScreen = {
     {{"cmd", "alt"}, "F"},
   },
+  almostFullScreen = {
+    {{"cmd", "alt", "shift"}, "F"},
+  },
   center = {
     {{"cmd", "alt"}, "C"},
   },

--- a/Source/Lunette.spoon/resize.lua
+++ b/Source/Lunette.spoon/resize.lua
@@ -26,6 +26,16 @@ function obj:fullScreen(window, screen)
   return window
 end
 
+function obj:almostFullScreen(window, screen)
+   window.w = screen.w - (screen.w // 10)
+   window.h = screen.h - (screen.h // 10)
+   -- also, center
+   window.x = ((screen.w - window.w) // 2) + screen.x
+   window.y = ((screen.h - window.h) // 2) + screen.y
+
+   return window
+end
+
 function obj:center(window, screen)
   window.x = ((screen.w - window.w) // 2) + screen.x
   window.y = ((screen.h - window.h) // 2) + screen.y


### PR DESCRIPTION
This change adds a command that used to be in the Spectacle app, to resize a window to take up most but not all of the screen size. It is bound to the same keybinding as `fullScreen`, but adding the Shift key.

The resized window is then centered, leaving some padding space between the window and the borders of the desktop.

Also, please note that Lua is not a language that I know well. If you have any improvement suggestions, please go ahead 😄 